### PR TITLE
Let OOMMF write binary output

### DIFF
--- a/oommfc/drivers/driver.py
+++ b/oommfc/drivers/driver.py
@@ -46,7 +46,7 @@ class Driver(mm.Driver):
 
     def drive(self, system, /, dirname='.', append=True, fixed_subregions=None,
               compute=None, output_step=False, n_threads=None, runner=None,
-              **kwargs):
+              ovf_format='bin8', **kwargs):
         """Drives the system in phase space.
 
         Takes ``micromagneticmodel.System`` and drives it in the phase space.
@@ -90,6 +90,13 @@ class Driver(mm.Driver):
             OOMMF Runner which is going to be used for running OOMMF. If
             ``None``, OOMMF runner will be found automatically. Defaults to
             ``None``.
+
+        ovf_format : str
+
+            Format of the magnetisation output files written by OOMMF. Can be
+            one of ``'bin8'`` (binary, double precision), ``'bin4'`` (binary,
+            single precision) or ``'txt'`` (text-based, double precision).
+            Defaults to ``'bin8'``.
 
         Raises
         ------
@@ -184,7 +191,7 @@ class Driver(mm.Driver):
             jsonfilename = 'info.json'
 
             # Generate and save mif file.
-            mif = oc.scripts.system_script(system)
+            mif = oc.scripts.system_script(system, ovf_format=ovf_format)
             mif += oc.scripts.driver_script(self, system,
                                             fixed_subregions=fixed_subregions,
                                             output_step=output_step,

--- a/oommfc/scripts/system.py
+++ b/oommfc/scripts/system.py
@@ -7,8 +7,8 @@ def system_script(system, **kwargs):
     mif += 'SetOptions {\n'
     mif += f'  basename {system.name}\n'
     mif += '  scalar_output_format %.12g\n'
-    mif += '  scalar_field_output_format {text %#.15g}\n'
-    mif += '  vector_field_output_format {text %#.15g}\n'
+    mif += '  scalar_field_output_format {binary 8}\n'
+    mif += '  vector_field_output_format {binary 8}\n'
     mif += '}\n\n'
 
     # Mesh and energy scripts.

--- a/oommfc/scripts/system.py
+++ b/oommfc/scripts/system.py
@@ -1,14 +1,22 @@
 import oommfc as oc
 
 
-def system_script(system, **kwargs):
+def system_script(system, ovf_format, **kwargs):
+    if ovf_format == 'bin8':
+        output_format = 'binary 8'
+    elif ovf_format == 'bin4':
+        output_format = 'binary 4'
+    elif ovf_format == 'txt':
+        output_format = 'text %#.15g'
+    else:
+        raise ValueError(f'Invalid {ovf_format=}.')
     mif = '# MIF 2.2\n\n'
     # Output options
     mif += 'SetOptions {\n'
     mif += f'  basename {system.name}\n'
     mif += '  scalar_output_format %.12g\n'
-    mif += '  scalar_field_output_format {binary 8}\n'
-    mif += '  vector_field_output_format {binary 8}\n'
+    mif += f'  scalar_field_output_format {{{output_format}}}\n'
+    mif += f'  vector_field_output_format {{{output_format}}}\n'
     mif += '}\n\n'
 
     # Mesh and energy scripts.


### PR DESCRIPTION
The header is always plain ASCII so opening the file and seeing something
meaningful is still possible.