### PR TITLE
Faster update of the magnetisation

### DIFF
--- a/oommfc/drivers/driver.py
+++ b/oommfc/drivers/driver.py
@@ -237,7 +237,7 @@ class Driver(mm.Driver):
                 # test_sample-Oxs_TimeDriver-Magnetization-01-0000008.omf
                 omffiles = glob.iglob(f'{system.name}*.omf')
                 lastomffile = sorted(omffiles)[-1]
-                system.m.value = df.Field.fromfile(lastomffile)
+                system.m.value = df.Field.fromfile(lastomffile).array
 
                 # Update system's datatable.
                 if isinstance(self, oc.TimeDriver):


### PR DESCRIPTION
To speed up the update of the magnetisation we can pass the array of the field
instead of the new field that we read from disk. Thereby we do not anymore pass
a callable and can gain huge speedups > 1e3.