### PR TITLE
Show progressbar during TimeDrive

### DIFF
--- a/oommfc/drivers/driver.py
+++ b/oommfc/drivers/driver.py
@@ -120,7 +120,7 @@ class Driver(mm.Driver):
             the OOMMF runner and the runtime is printed to stdout. For ``verbose=2`` a
             progress bar is displayed for time drives. Note, that this information only
             relies on the number of magnetisation snapshot already saved to disk and
-            therefore only gives a rough indication of progress. The default 
+            therefore only gives a rough indication of progress. The default
             is ``verbose=1``.
 
         Raises

--- a/oommfc/drivers/driver.py
+++ b/oommfc/drivers/driver.py
@@ -120,7 +120,8 @@ class Driver(mm.Driver):
             the OOMMF runner and the runtime is printed to stdout. For ``verbose=2`` a
             progress bar is displayed for time drives. Note, that this information only
             relies on the number of magnetisation snapshot already saved to disk and
-            therefore only gives a rough hint. Defaults is ``verbose=1``.
+            therefore only gives a rough indication of progress. The default 
+            is ``verbose=1``.
 
         Raises
         ------

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -54,7 +54,7 @@ class OOMMFRunner(metaclass=abc.ABCMeta):
             the OOMMF runner and the runtime is printed to stdout. For ``verbose=2`` a
             progress bar is displayed for time drives. Note, that this information only
             relies on the number of magnetisation snapshot already saved to disk and
-            therefore only gives an indication of progress. The default 
+            therefore only gives an indication of progress. The default
             is ``verbose=1``.
 
         n : int, optional

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -11,7 +11,7 @@ import time
 
 import micromagneticmodel as mm
 import ubermagutil as uu
-from tqdm.autonotebook import tqdm  # different styles for notebook and command line
+from tqdm.auto import tqdm  # different styles for notebook and command line
 
 import oommfc as oc
 

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -98,7 +98,9 @@ class OOMMFRunner(metaclass=abc.ABCMeta):
                 progressbar = tqdm(
                     total=n,
                     desc="Running OOMMF",
-                    bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}]",
+                    bar_format=(
+                        "{l_bar}{bar}| {n_fmt}/{total_fmt} files written [{elapsed}]"
+                    ),
                 )
                 progressbar.set_postfix_str("[{elapsed}]")
                 bar_update = asyncio.create_task(self._barupdate(progressbar, globname))

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -54,7 +54,8 @@ class OOMMFRunner(metaclass=abc.ABCMeta):
             the OOMMF runner and the runtime is printed to stdout. For ``verbose=2`` a
             progress bar is displayed for time drives. Note, that this information only
             relies on the number of magnetisation snapshot already saved to disk and
-            therefore only gives a rough hint. Defaults is ``verbose=1``.
+            therefore only gives an indication of progress. The default 
+            is ``verbose=1``.
 
         n : int, optional
 

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -10,8 +10,8 @@ import sys
 import time
 
 import micromagneticmodel as mm
-import tqdm
 import ubermagutil as uu
+from tqdm.autonotebook import tqdm  # different styles for notebook and command line
 
 import oommfc as oc
 
@@ -95,7 +95,12 @@ class OOMMFRunner(metaclass=abc.ABCMeta):
                 now.year, now.month, now.day, now.hour, now.minute
             )
             if verbose >= 2 and n:
-                progressbar = tqdm.tqdm(total=n, desc="Running OOMMF")
+                progressbar = tqdm(
+                    total=n,
+                    desc="Running OOMMF",
+                    bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}]",
+                )
+                progressbar.set_postfix_str("[{elapsed}]")
                 bar_update = asyncio.create_task(self._barupdate(progressbar, globname))
             else:
                 print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ classifiers = [
 dependencies = [
     "micromagnetictests~=0.61.1",
     "ubermagtable~=0.61.0",
-    "micromagneticdata~=0.61.0"
+    "micromagneticdata~=0.61.0",
+    "tqdm"
 ]
 
 [project.optional-dependencies]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     micromagnetictests~=0.61.1
     ubermagtable~=0.61.0
     micromagneticdata~=0.61.0
+    tqdm
 include_package_data = True
 
 [options.extras_require]


### PR DESCRIPTION
This PR adds a simple progressbar for TimeDrive runs for `verbose=2`. Progress is estimated base on the total number of steps to save (`n`) and the number of files already written to disk. Estimating progress based on this is not super accurate as the simulation can get slower/faster but it is a useful hint for interactive inside a notebook.

During the simulation:
![grafik](https://user-images.githubusercontent.com/67915889/168223722-18eec52d-ee35-4dc4-b211-ccd7f77d3835.png)

After the simulation is finished:
![grafik](https://user-images.githubusercontent.com/67915889/168223844-2f4e0738-f8c5-4cdd-ad39-82789e23c499.png)
