### PR TITLE
Fix: multiple OOMMF runs interfere when started using schedule

### DIFF
--- a/oommfc/drivers/driver.py
+++ b/oommfc/drivers/driver.py
@@ -213,6 +213,16 @@ class Driver(mm.ExternalDriver):
                 glob_name=f"{system.name}*.omf",
             )
 
+    def _schedule_commands(self, system, runner):
+        if runner is None:
+            runner = oc.runner.runner
+        commands = []
+        commands.append(f"OOMMF_HOSTPORT=`{runner._launchhost(dry_run=True)}`")
+        commands.append("export OOMMF_HOSTPORT")
+        commands.append(runner.call(argstr=self._miffilename(system), dry_run=True))
+        commands.append(runner._kill(dry_run=True))
+        return commands
+
     def _read_data(self, system):
         # Update system's magnetisation. An example .omf filename:
         # test_sample-Oxs_TimeDriver-Magnetization-01-0000008.omf

--- a/oommfc/oommf/oommf.py
+++ b/oommfc/oommf/oommf.py
@@ -40,8 +40,12 @@ class OOMMFRunner(mm.ExternalRunner):
         """This method should be implemented in subclass."""
 
     @abc.abstractmethod
-    def _kill(self, targets=("all",)):
+    def _kill(self, targets=("all",), dry_run=False):
         """Kill OOMMF."""
+
+    @abc.abstractmethod
+    def _launchhost(dry_run=False):
+        """Launch the OOMMF host server."""
 
     @abc.abstractmethod
     def errors(self):
@@ -156,14 +160,21 @@ class NativeOOMMFRunner(OOMMFRunner):
         # oommf launchhost gets stuck on Windows
         # -> it is not possible to run multiple calculations in parallel
         if sys.platform != "win32":
-            launchhost = sp.run([*self.oommf, "launchhost", "0"], stdout=sp.PIPE)
-            port = launchhost.stdout.decode("utf-8", "replace").strip("\n")
-            self.env = dict(OOMMF_HOSTPORT=port, **os.environ)
+            self.env = dict(OOMMF_HOSTPORT=self._launchhost(), **os.environ)
         else:
             self.env = os.environ
 
+    def _launchhost(self, dry_run=False):
+        command = [*self.oommf, "launchhost", "0"]
+        if dry_run:
+            return " ".join(command)
+        else:
+            launchhost = sp.run(command, stdout=sp.PIPE)
+            port = launchhost.stdout.decode("utf-8", "replace").strip("\n")
+            return port
+
     def _call(self, argstr, need_stderr=False, n_threads=None, dry_run=False):
-        cmd = [*self.oommf, "boxsi", "+fg", argstr, "-exitondone", "1"]
+        command = [*self.oommf, "boxsi", "+fg", argstr, "-exitondone", "1"]
 
         # Not clear why we cannot get stderr and stdout on win32. Calls to
         # OOMMF get stuck.
@@ -172,13 +183,13 @@ class NativeOOMMFRunner(OOMMFRunner):
             stdout = stderr = None  # pragma: no cover
 
         if n_threads is not None:
-            cmd += ["-threads", str(n_threads)]
+            command += ["-threads", str(n_threads)]
 
         if dry_run:
-            return cmd
+            return " ".join(command)
         else:
             with self._kill_oommf_on_windows():
-                return sp.run(cmd, stdout=stdout, stderr=stderr, env=self.env)
+                return sp.run(command, stdout=stdout, stderr=stderr, env=self.env)
 
     @contextlib.contextmanager
     def _kill_oommf_on_windows(self, targets=("all",)):
@@ -189,8 +200,14 @@ class NativeOOMMFRunner(OOMMFRunner):
             if sys.platform == "win32":
                 self._kill()
 
-    def _kill(self, targets=("all",)):
-        sp.run([*self.oommf, "killoommf", "-q"] + list(targets), env=self.env)
+    def _kill(self, targets=("all",), dry_run=False):
+        command = [*self.oommf, "killoommf"] + list(targets)
+        if dry_run:
+            return " ".join(command)
+        else:
+            # Quietly kill oommf when used interactively
+            command.insert(-1, "-q")
+            sp.run(command, env=self.env)
 
 
 @uu.inherit_docs
@@ -289,6 +306,10 @@ class DockerOOMMFRunner(OOMMFRunner):
         self.image = image
         self.selinux = selinux
 
+    def _launchhost(self, dry_run=False):
+        if dry_run:
+            return ""
+
     def _call(self, argstr, need_stderr=False, n_threads=None, dry_run=False):
         cmd = [
             self.docker_exe,
@@ -303,13 +324,14 @@ class DockerOOMMFRunner(OOMMFRunner):
         if n_threads is not None:
             cmd += ["-threads", str(n_threads)]
         if dry_run:
-            return cmd
+            return " ".join(cmd)
         else:
             return sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
 
-    def _kill(self, targets=("all",)):
+    def _kill(self, targets=("all",), dry_run=False):
         # There is no need to kill OOMMF when run inside docker.
-        pass
+        if dry_run:
+            return ""
 
     def errors(self):
         msg = "boxsi.errors cannot be retrieved from Docker container."


### PR DESCRIPTION
To ensure that calls to OOMMF are fully independent we need to use the launchhost command provided by OOMMF. This is done when running simulations "directly" using `driver.drive(...)`. The same is now also done when scheduling a run.