### PR TITLE
Filter out unsupported tests

### DIFF
--- a/oommfc/tests/conftest.py
+++ b/oommfc/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 import oommfc as oc
 
-not_supported_by_oommf = ["test_check_for_energy_and_dynamics", "test_relaxdriver"]
+not_supported_by_oommf = ["test_relax_check_for_energy", "test_relaxdriver"]
 
 
 @pytest.fixture(scope="module")

--- a/oommfc/tests/conftest.py
+++ b/oommfc/tests/conftest.py
@@ -2,7 +2,20 @@ import pytest
 
 import oommfc as oc
 
+not_supported_by_oommf = ["test_check_for_energy_and_dynamics", "test_relaxdriver"]
+
 
 @pytest.fixture(scope="module")
 def calculator():
     return oc
+
+
+@pytest.fixture(autouse=True)
+def skip_unsupported_or_missing(request):
+    requesting_test_function = (
+        f"{request.cls.__name__}.{request.function.__name__}"
+        if request.cls
+        else request.function.__name__
+    )
+    if requesting_test_function in not_supported_by_oommf:
+        pytest.skip("Not supported by OOMMF.")


### PR DESCRIPTION
ubermag/micromagnetictests#47 introduces additional tests for the relax driver which is not supported in oommf.