### PR TITLE
adapt conftest.py to removed classes in micromagnetictests

### DIFF
--- a/oommfc/tests/conftest.py
+++ b/oommfc/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 import oommfc as oc
 
-not_supported_by_oommf = ["test_relax_check_for_energy", "test_relaxdriver"]
+not_supported_by_oommf = {"test_relax_check_for_energy", "test_relaxdriver"}
 
 
 @pytest.fixture(scope="module")
@@ -12,10 +12,6 @@ def calculator():
 
 @pytest.fixture(autouse=True)
 def skip_unsupported_or_missing(request):
-    requesting_test_function = (
-        f"{request.cls.__name__}.{request.function.__name__}"
-        if request.cls
-        else request.function.__name__
-    )
+    requesting_test_function = request.function.__name__
     if requesting_test_function in not_supported_by_oommf:
         pytest.skip("Not supported by OOMMF.")


### PR DESCRIPTION
## Summary

Update the `micromagnetictests` skip logic after the class-removal refactor in ubermag/micromagnetictests#72.

The calculator tests are now exposed as module-level pytest functions instead of `Test...` classes. The OOMMF-specific skip list already used the new flat `test_...` names, so this PR simplifies the skip lookup to match the new collection structure directly.

## Changes

- Keep `not_supported_by_oommf` keyed by the new flat `test_...` function names.
- Remove the old `request.cls` handling from the skip lookup.
- Store `not_supported_by_oommf` as a set for direct membership checks.
